### PR TITLE
chore: update to use @toplocs/plugin-sdk from npm

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -1,6 +1,6 @@
 // Plugin Development Environment
-import { createPluginDevelopmentEnvironment, type PluginDevConfig } from '@toplocs/plugin-dev-sdk';
-import '@toplocs/plugin-dev-sdk/style.css';
+import { createPluginDevelopmentEnvironment, type PluginDevConfig } from '@toplocs/plugin-sdk';
+import '@toplocs/plugin-sdk/style.css';
 
 // Import plugin configuration and components
 import pluginConfig from './src/index';

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   },
   "dependencies": {
     "@heroicons/vue": "^2.2.0",
-    "@toplocs/plugin-dev-sdk": "file:../plugin-dev-sdk",
+    "@toplocs/plugin-sdk": "^1.0.0",
     "gun": "^0.2020.1240",
     "vue": "^3.5.12",
     "vue-router": "^4.4.5"

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -4,7 +4,7 @@ export default {
   content: [
     "./index.html",
     "./src/**/*.{vue,js,ts,jsx,tsx}",
-    "./node_modules/@toplocs/plugin-dev-sdk/dist/**/*.{js,css}",
+    "./node_modules/@toplocs/plugin-sdk/dist/**/*.{js,css}",
   ],
   theme: {
     extend: {},


### PR DESCRIPTION
## Summary
Update link-plugin to use the published npm package `@toplocs/plugin-sdk` instead of the local file dependency.

## Changes
- 📦 Update `package.json` to use `@toplocs/plugin-sdk@^1.0.0` from npm
- 🔄 Update all imports from `@toplocs/plugin-dev-sdk` to `@toplocs/plugin-sdk`
- 📝 Update Tailwind config to use the correct package path

## Benefits
- ✅ **Reliable dependency management** - Using published npm package
- ✅ **Easier setup** - No need to have local plugin-sdk directory
- ✅ **Version control** - Can specify exact versions for consistency
- ✅ **Better CI/CD** - Works in any environment without local dependencies

## NPM Package
https://www.npmjs.com/package/@toplocs/plugin-sdk

## Test plan
- [ ] Run `pnpm install` - Dependencies install from npm
- [ ] Run `pnpm build` - Build completes successfully
- [ ] Run `pnpm dev` - Development server works correctly

🤖 Generated with [Claude Code](https://claude.ai/code)