### PR TITLE
feat: add Vue-based info page using SDK components

### DIFF
--- a/landing.html
+++ b/landing.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8">
+    <link rel="icon" href="/favicon.ico">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>TopLocs Link Plugin</title>
+  </head>
+  <body>
+    <div id="app"></div>
+    <script type="module" src="/src/info.ts"></script>
+  </body>
+</html>

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
-    "build": "vite build",
+    "build": "vite build && mv dist/landing.html dist/index.html",
     "preview": "pnpm build && run-p preview:plugin dev",
     "preview:plugin": "vite preview --port 3006",
     "test": "vitest",
@@ -14,7 +14,7 @@
   },
   "dependencies": {
     "@heroicons/vue": "^2.2.0",
-    "@toplocs/plugin-sdk": "^1.0.0",
+    "@toplocs/plugin-sdk": "^1.1.0",
     "gun": "^0.2020.1240",
     "vue": "^3.5.12",
     "vue-router": "^4.4.5"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,9 +11,9 @@ importers:
       '@heroicons/vue':
         specifier: ^2.2.0
         version: 2.2.0(vue@3.5.17(typescript@5.5.4))
-      '@toplocs/plugin-dev-sdk':
-        specifier: file:../plugin-dev-sdk
-        version: file:../plugin-dev-sdk(vue-router@4.5.1(vue@3.5.17(typescript@5.5.4)))(vue@3.5.17(typescript@5.5.4))
+      '@toplocs/plugin-sdk':
+        specifier: ^1.1.0
+        version: 1.1.0(vue-router@4.5.1(vue@3.5.17(typescript@5.5.4)))(vue@3.5.17(typescript@5.5.4))
       gun:
         specifier: ^0.2020.1240
         version: 0.2020.1241
@@ -592,8 +592,8 @@ packages:
   '@swc/types@0.1.23':
     resolution: {integrity: sha512-u1iIVZV9Q0jxY+yM2vw/hZGDNudsN85bBpTqzAQ9rzkxW9D+e3aEM4Han+ow518gSewkXgjmEK0BD79ZcNVgPw==}
 
-  '@toplocs/plugin-dev-sdk@file:../plugin-dev-sdk':
-    resolution: {directory: ../plugin-dev-sdk, type: directory}
+  '@toplocs/plugin-sdk@1.1.0':
+    resolution: {integrity: sha512-PQgDLopeIxaeMLq1WdoIEUz84HDBZ4UARR9CN3v+KhW+AUEpkfptr+acP8ebX9IXOOc9EDrMZZuQz5Fea2K7Rg==}
     peerDependencies:
       vue: ^3.0.0
       vue-router: ^4.0.0
@@ -2426,7 +2426,7 @@ snapshots:
     dependencies:
       '@swc/counter': 0.1.3
 
-  '@toplocs/plugin-dev-sdk@file:../plugin-dev-sdk(vue-router@4.5.1(vue@3.5.17(typescript@5.5.4)))(vue@3.5.17(typescript@5.5.4))':
+  '@toplocs/plugin-sdk@1.1.0(vue-router@4.5.1(vue@3.5.17(typescript@5.5.4)))(vue@3.5.17(typescript@5.5.4))':
     dependencies:
       '@originjs/vite-plugin-federation': 1.4.1
       vue: 3.5.17(typescript@5.5.4)

--- a/src/InfoPage.vue
+++ b/src/InfoPage.vue
@@ -1,0 +1,75 @@
+<template>
+  <PluginInfoPage
+    :plugin-config="pluginConfig"
+    icon="🔗"
+    :about="about"
+    :features="features"
+    :endpoints="endpoints"
+    :development="development"
+    :slot-descriptions="slotDescriptions"
+  />
+</template>
+
+<script setup lang="ts">
+import { PluginInfoPage } from '@toplocs/plugin-sdk'
+import pluginConfig from './index'
+
+const about = `
+The Link Plugin enables communities to share, organize, and discover valuable resources through curated link collections. It seamlessly integrates with TopLocs spheres to provide topic-specific link management with rich metadata and Gun.js P2P synchronization.
+`
+
+const features = [
+  {
+    icon: '🔖',
+    title: 'Link Collection',
+    description: 'Save and organize links with titles, descriptions, and automatic metadata extraction'
+  },
+  {
+    icon: '📱',
+    title: 'Share Extension',
+    description: 'Built-in share extension for easy link saving from any browser tab'
+  },
+  {
+    icon: '🏷️',
+    title: 'Topic Integration',
+    description: 'Links are automatically associated with the current topic or location context'
+  },
+  {
+    icon: '🔄',
+    title: 'P2P Sync',
+    description: 'Real-time synchronization across all sphere members using Gun.js'
+  },
+  {
+    icon: '👁️',
+    title: 'Rich Previews',
+    description: 'Automatic extraction of link metadata including title, description, and preview images'
+  },
+  {
+    icon: '⚙️',
+    title: 'Flexible Settings',
+    description: 'Configure link display preferences and sharing options per sphere'
+  }
+]
+
+const endpoints = {
+  plugin: 'http://localhost:3006/assets/plugin.js',
+  landing: 'https://toplocs.github.io/link-plugin',
+  demo: 'http://localhost:3000'
+}
+
+const development = {
+  stack: ['Vue 3', 'TypeScript', 'Gun.js', 'Tailwind CSS'],
+  setup: `pnpm install && pnpm dev`,
+  urls: [
+    { label: 'GitHub Repository', url: 'https://github.com/toplocs/link-plugin' },
+    { label: 'Plugin Development', url: 'http://localhost:3006' }
+  ]
+}
+
+const slotDescriptions = {
+  'Topic → Info → Sidebar': 'Sidebar: Displays recent links and quick add functionality',
+  'Topic → Settings → Content': 'Content: Link sharing preferences and display options',
+  'Location → Info → Sidebar': 'Sidebar: Location-specific link collections',
+  'Location → Settings → Content': 'Content: Location-based link settings'
+}
+</script>

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,22 +3,7 @@
  * This file defines the plugin configuration and exports it for use in TopLocs
  */
 
-interface BasePluginConfig {
-  id: string;
-  name: string;
-  url: string;
-  version?: string;
-  description?: string;
-  author?: string;
-  slots: Array<PluginSlot>;
-}
-
-interface PluginSlot {
-  entity: 'Topic' | 'Location';
-  page: 'Info' | 'Settings';
-  slot: 'Content' | 'Sidebar';
-  component: string;
-}
+import type { BasePluginConfig } from '@toplocs/plugin-sdk'
 
 const pluginConfig: BasePluginConfig = {
   id: 'link_plugin',

--- a/src/info.ts
+++ b/src/info.ts
@@ -1,0 +1,5 @@
+import { createApp } from 'vue'
+import InfoPage from './InfoPage.vue'
+import '@toplocs/plugin-sdk/style.css'
+
+createApp(InfoPage).mount('#app')

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -56,6 +56,10 @@ export default defineConfig({
       mangle: false,
     },
     rollupOptions: {
+      input: {
+        main: path.resolve(__dirname, 'index.html'),
+        landing: path.resolve(__dirname, 'landing.html')
+      },
       external: ['vue'],
       output: {
         globals: {


### PR DESCRIPTION
## Summary
- Updated to @toplocs/plugin-sdk 1.1.0 which includes new info page components
- Created Vue-based landing page using PluginInfoPage component from SDK
- Configured multi-entry build to generate both plugin and landing page

## Changes
- Updated SDK dependency to 1.1.0
- Added InfoPage.vue using SDK's PluginInfoPage component
- Created landing.html and src/info.ts entry points
- Modified vite.config.ts for multiple entry points
- Updated build script to output landing page as index.html
- Updated plugin config to use SDK types

## Test plan
- [x] Build completes successfully
- [x] Landing page generated at dist/index.html
- [x] Plugin functionality remains intact

🤖 Generated with [Claude Code](https://claude.ai/code)